### PR TITLE
Add ostream support to print_1Dview

### DIFF
--- a/perf_test/graph/KokkosGraph_color.cpp
+++ b/perf_test/graph/KokkosGraph_color.cpp
@@ -82,14 +82,14 @@ void print_options(std::ostream &os, const char *app_name, unsigned int indent =
        << spaces << "                 COLORING_VBDBIT   - Use the vertex-based deterministic with bit vectors method." << std::endl
        << std::endl
        << spaces << "  Optional Parameters:" << std::endl
-       << spaces << "      --repeat <N>        Set number of test repetitions (Default: 1) " << std::endl
-       << spaces << "      --verbose           Enable verbose mode (record and print timing + extra information)" << std::endl
        << spaces << "      --chunksize <N>     Set the chunk size." << std::endl
        << spaces << "      --dynamic           Use dynamic scheduling." << std::endl
+       << spaces << "      --outputfile <FILE> Output the colors of the nodes to the file." << std::endl
+       << spaces << "      --repeat <N>        Set number of test repetitions (Default: 1) " << std::endl
        << spaces << "      --teamsize  <N>     Set the team size." << std::endl
        << spaces << "      --vectorsize <N>    Set the vector size." << std::endl
+       << spaces << "      --verbose           Enable verbose mode (record and print timing + extra information)" << std::endl
        << spaces << "      --help              Print out command line help." << std::endl
-       << spaces << "      --outputfile <FILE> Output the colors of the nodes to the file." << std::endl
        << spaces << " " << std::endl;
 }
 
@@ -304,7 +304,8 @@ void run_experiment(
     std::cout << "\t"; KokkosKernels::Impl::print_1Dview(kh.get_graph_coloring_handle()->get_vertex_colors());
 
     if( params.coloring_output_file != NULL ) {
-      KokkosKernels::Impl::print_to_file(kh.get_graph_coloring_handle()->get_vertex_colors(), params.coloring_output_file);
+      std::ofstream os(params.coloring_output_file, std::ofstream::out);
+      KokkosKernels::Impl::print_1Dview(os, kh.get_graph_coloring_handle()->get_vertex_colors(), true, "\n"); 
     }
   }
 }

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -47,6 +47,7 @@
 #include "Kokkos_Atomic.hpp"
 #include "impl/Kokkos_Timer.hpp"
 #include <fstream>
+#include <ostream>
 
 namespace KokkosKernels{
 
@@ -90,69 +91,74 @@ inline void kk_get_histogram(
   MyExecSpace().fence();
 }
 
+
+/**
+ * \brief Prints the given 1D view.
+ * \param os: Stream to print to. To print to stdout use std::cout, stderr, std::cerr, or a file use an ofstream object.
+ * \param view: input view to print.
+ * \param print_all: whether to print all elements or not. If it is false, print print_size/2 first and last elements.
+ * \param sep: Element separator. Default is a single space: " "
+ * \param print_size: Total elements to print if print_all is false print_size/2 first and last elements are pritned.
+ *                    This parameter is not used if print_all is set to true.
+ */
+template <typename idx_array_type>
+inline void kk_print_1Dview(std::ostream& os, idx_array_type view, bool print_all=false, const char* sep=" ", size_t print_size=40)
+{
+  typedef typename idx_array_type::HostMirror host_type;
+  typedef typename idx_array_type::size_type idx;
+  host_type host_view = Kokkos::create_mirror_view (view);
+  Kokkos::deep_copy (host_view, view);
+  idx nr = host_view.extent(0);
+  if (!print_all)
+  {
+    if (nr > print_size)
+    {
+      idx n = print_size / 2;
+      for (idx i = 0; i < n; ++i)
+      {
+        os << host_view(i) << sep;
+      }
+      os << "... ... ..." << sep;
+
+      for (idx i = nr-n; i < nr; ++i)
+      {
+        os << host_view(i) << sep;
+      }
+      os << std::endl;
+    }
+    else
+    {
+      for (idx i = 0; i < nr; ++i)
+      {
+        os << host_view(i) << sep;
+      }
+      os << std::endl;
+    }
+  }
+  else
+  {
+    for (idx i = 0; i < nr; ++i)
+    {
+      os << host_view(i) << sep;
+    }
+    os << std::endl;
+  }
+}
+
+
 /**
  * \brief Prints the given 1D view.
  * \param view: input view to print.
  * \param print_all: whether to print all elements or not. If it is false,
- * only first and last 10 elements are printed.
+ * only first and last 20 elements are printed.
+ * 
+ * This interface is provided for backwards compatiblity.
  */
 template <typename idx_array_type>
 inline void kk_print_1Dview(idx_array_type view, bool print_all = false, size_t print_size = 40){
 
-  typedef typename idx_array_type::HostMirror host_type;
-  typedef typename idx_array_type::size_type idx;
-  host_type host_view = Kokkos::create_mirror_view (view);
-  Kokkos::deep_copy (host_view , view);
-  idx nr = host_view.extent(0);
-  if (!print_all){
+  kk_print_1Dview(std::cout, view, print_all, " ", print_size);
 
-
-    if (nr > print_size){
-      idx n = print_size / 2;
-      for (idx i = 0; i < n; ++i){
-        std::cout << host_view(i) << " ";
-      }
-      std::cout << "... ... ... ";
-
-      for (idx i = nr-n; i < nr; ++i){
-        std::cout << host_view(i) << " ";
-      }
-      std::cout << std::endl;
-    }
-    else {
-      for (idx i = 0; i < nr; ++i){
-        std::cout << host_view(i) << " ";
-      }
-      std::cout << std::endl;
-    }
-  }
-  else {
-    for (idx i = 0; i < nr; ++i){
-      std::cout << host_view(i) << " ";
-    }
-    std::cout << std::endl;
-  }
-}
-
-/**
- * \brief Stores the given view to a file.
- * \param view: input view to store.
- * \param file: the output file where the view is to be stored.
- */
-template <typename idx_array_type>
-inline void kk_print_to_file(idx_array_type view, char* file){
-
-  typedef typename idx_array_type::HostMirror host_type;
-  typedef typename idx_array_type::size_type idx;
-  host_type host_view = Kokkos::create_mirror_view (view);
-  Kokkos::deep_copy (host_view , view);
-  idx nr = host_view.extent(0);
-  std::ofstream out;
-  out.open(file);
-
-  for(idx i = 0; i < nr; ++i){
-    out << host_view(i) << "\n";
-  }
 }
 
 }

--- a/src/common/KokkosKernels_PrintUtils.hpp
+++ b/src/common/KokkosKernels_PrintUtils.hpp
@@ -46,7 +46,6 @@
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Atomic.hpp"
 #include "impl/Kokkos_Timer.hpp"
-#include <fstream>
 #include <ostream>
 
 namespace KokkosKernels{

--- a/src/common/KokkosKernels_Utils.hpp
+++ b/src/common/KokkosKernels_Utils.hpp
@@ -567,14 +567,15 @@ struct FillSymmetricEdgeList_HashMap{
 
   }
 };
+
 template <typename idx_array_type>
-void print_1Dview(idx_array_type view, bool print_all = false){
-  kk_print_1Dview(view, print_all);
+void print_1Dview(std::ostream& os, idx_array_type view, bool print_all=false, const char* sep=" "){
+  kk_print_1Dview(os, view, print_all, sep);
 }
 
 template <typename idx_array_type>
-void print_to_file(idx_array_type view, char* file){
-  kk_print_to_file(view, file);
+void print_1Dview(idx_array_type view, bool print_all = false){
+  kk_print_1Dview(view, print_all);
 }
 
 template <typename lno_t, typename memory_space>


### PR DESCRIPTION
Hi @rohit-mp 

I made some mods to the branch you have in your PR... feel free to have a look and merge this into your branch, which should update your existing PR into KokkosKernels.

Essentially, I removed the `print_to_file` function and made a new `print_1Dview()` function that adds an output stream and a separator to its parameter lists.  I maintain backwards compatibility with a wrapper version of `print_1Dview()` so existing uses of the function won't break.

This adds extra flexibility to the 1D view printing... for example:

To print out the same thing as has always been printed:  
```C++
print_1Dview(std::cout, my_view);
```

To print one value per line to a file:
```C++
std::ofstream os(filename, std::ofstream::out);
print_1Dview(os, my_view, true, "\n");
```

To print all values to one line using a comma to separate values:
```C++
std::ofstream os(filename, std::ofstream::out);
print_1Dview(os, my_view, true, ",");
```
The above example can be changed to _append_ to a file rather than overwrite if you wanted to create a CSV file that stores each run on a separate row of the file:
```C++
std::ofstream os(filename, std::ofstream::out);
std::ofstream outfile;
outfile.open(filename, std::ofstream::out | std::ofstream::app);
print_1Dview(os, my_view, true, ",");
```
Which solves the issue you raised with the example when running with > 1 repetitions since you could save the results of all the runs into one file where each row saved the colors from each run.

I ran this through the spot-check tool on a linux system for serial and openmp and it came back clean.  If you like this and update your branch, I can run more comprehensive spot-checks on it and will report that to the PR... 
